### PR TITLE
Add support for redpanda installation in M1

### DIFF
--- a/Formula/redpanda.rb
+++ b/Formula/redpanda.rb
@@ -1,12 +1,20 @@
 class Redpanda < Formula
     desc "Fastest Queue in the West"
-    homepage "https://www.vectorized.io"
-    url "https://github.com/redpanda-data/redpanda/releases/download/v22.1.3/rpk-darwin-amd64.zip"
+    homepage "https://www.redpanda.com"
     version "22.1.3"
-    sha256 "2956dcf87cc12055bc65545aa4269a034e2880af686f7e438a9caa2fa5a1854b"
 
-    def install
-        bin.install "rpk"
+    on_macos do
+        if Hardware::CPU.arm?
+            url "https://github.com/redpanda-data/redpanda/releases/download/v22.1.3/rpk-darwin-arm64.zip"
+            sha256 "56dac79665f9a5606019cead4d51bbd955a46e2888b257e631e47cb0df4ff203"
+        end
+        if Hardware::CPU.intel?
+            url "https://github.com/redpanda-data/redpanda/releases/download/v22.1.3/rpk-darwin-amd64.zip"
+            sha256 "2956dcf87cc12055bc65545aa4269a034e2880af686f7e438a9caa2fa5a1854b"
+        end
+        def install
+          bin.install "rpk"
+        end
     end
 
     def caveats; <<~EOS


### PR DESCRIPTION
This PR adds support for redpanda installation on Mac M1 machines.