### PR TITLE
feat: add auto completion to rpk formula

### DIFF
--- a/Formula/redpanda.rb
+++ b/Formula/redpanda.rb
@@ -14,6 +14,7 @@ class Redpanda < Formula
 
       def install
         bin.install "rpk"
+        generate_completions_from_executable(bin/"rpk", "generate", "shell-completion", base_name: "rpk")
       end
     end
     if Hardware::CPU.arm?
@@ -22,6 +23,7 @@ class Redpanda < Formula
 
       def install
         bin.install "rpk"
+        generate_completions_from_executable(bin/"rpk", "generate", "shell-completion", base_name: "rpk")
       end
     end
   end
@@ -33,6 +35,7 @@ class Redpanda < Formula
 
       def install
         bin.install "rpk"
+        generate_completions_from_executable(bin/"rpk", "generate", "shell-completion", base_name: "rpk")
       end
     end
     if Hardware::CPU.intel?
@@ -41,6 +44,7 @@ class Redpanda < Formula
 
       def install
         bin.install "rpk"
+        generate_completions_from_executable(bin/"rpk", "generate", "shell-completion", base_name: "rpk")
       end
     end
   end


### PR DESCRIPTION
This follows: https://rubydoc.brew.sh/Formula.html#generate_completions_from_executable-instance_method

Tested locally in Linux:
```
$ brew install --build-from-source ./Formula/redpanda.rb 
Running `brew update --auto-update`...
==> Downloading https://ghcr.io/v2/homebrew/portable-ruby/portable-ruby/blobs/sha256:f7be167f7ac4f296b9f4c5874ceeea4aafd9999c3c7f2b0378cae7dd273e2322
######################################################################## 100.0%
==> Pouring portable-ruby-3.1.4.x86_64_linux.bottle.tar.gz
==> Homebrew collects anonymous analytics.
Read the analytics documentation (and how to opt-out) here:
  https://docs.brew.sh/Analytics
No analytics have been recorded yet (nor will be during this `brew` run).

Installing from the API is now the default behaviour!
You can save space and time by running:
  brew untap homebrew/core
==> Downloading https://formulae.brew.sh/api/formula.jws.json
######################################################################################################################################################## 100.0%
==> Downloading https://formulae.brew.sh/api/cask.jws.json
######################################################################################################################################################## 100.0%
==> Auto-updated Homebrew!
Updated 1 tap (buildkite/cli).
No changes to formulae.

==> Fetching redpanda
==> Downloading https://github.com/redpanda-data/redpanda/releases/download/v23.2.17/rpk-linux-amd64.zip
==> Downloading from https://objects.githubusercontent.com/github-production-release-asset-2e65be/309512982/02edbb95-ad0b-48ff-8e74-e1f11dfdaebf?X-Amz-Algorith
######################################################################################################################################################## 100.0%
==> Caveats
Redpanda Keeper (rpk) is Redpanda's command line interface (CLI)
utility. The rpk commands let you configure, manage, and tune
Redpanda clusters. They also let you manage topics, groups,
and access control lists (ACLs).
Start a three-node docker cluster locally:

    rpk container start -n 3

Interact with the cluster using commands like:

    rpk topic list

When done, stop and delete the docker cluster:

    rpk container purge

For more examples and guides, visit: https://docs.redpanda.com

zsh completions have been installed to:
  /home/linuxbrew/.linuxbrew/share/zsh/site-functions
```

And the autocompletion is written to /site-functions:
```
ls -l /home/linuxbrew/.linuxbrew/share/zsh/site-functions/
total 0
lrwxrwxrwx. 1 rvasquez rvasquez 39 Oct  5  2022 _brew -> ../../../Homebrew/completions/zsh/_brew
lrwxrwxrwx. 1 rvasquez rvasquez 62 Dec  6 15:24 _rpk -> ../../../Cellar/redpanda/23.2.17/share/zsh/site-functions/_rpk
```
![image](https://github.com/redpanda-data/homebrew-tap/assets/59714880/50db6bc7-fef9-4e5e-8a7a-d739612fe06c)


Fixes https://github.com/redpanda-data/redpanda/issues/12488